### PR TITLE
chore(tsconfig): target es2016

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ addons:
       - xvfb
 
 before_install:
-  - sudo sysctl fs.inotify.max_user_watches=524288
-  - export DISPLAY=':99.0'
-  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
 # package-lock.json was introduced in npm@5
   - '[[ $(node -v) =~ ^v9.*$ ]] || npm install -g npm@latest' # skipped when using node 9
   - npm install -g greenkeeper-lockfile@1

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
       "dom"
     ],
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2016",
     "strict": true,
     "importHelpers": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
So, without this we're getting: `TypeError: Class constructor Room cannot be invoked without 'new'` - with the new Collyseus version.

As per this: https://discuss.colyseus.io/topic/57/room-error-solved/2
I changed the target and it worked.